### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/georgetown-analytics/clockr.png?label=ready&title=Ready)](https://waffle.io/georgetown-analytics/clockr)
 # clockr
 Simple current timestamp printing app


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/georgetown-analytics/clockr

This was requested by a real person (user bbengfort) on waffle.io, we're not trying to spam you.
